### PR TITLE
add configure 

### DIFF
--- a/paper-trackr/core/actions.py
+++ b/paper-trackr/core/actions.py
@@ -3,10 +3,13 @@ from core.biorxiv_request import check_biorxiv_feeds
 from core.pubmed_request import search_pubmed
 from core.epmc_request import search_epmc
 from core.mailer import send_email
+from core.configure import configure_email_accounts
 import yaml
 import argparse
 import os
+import sys
 
+CONFIG_PATH = "paper-trackr/config/accounts.yml"
 SEARCH_QUERIES_FILE = "paper-trackr/config/search_queries.yml"
 
 # load queries from search_queries.yml
@@ -20,9 +23,15 @@ def save_search_queries(queries):
     with open(SEARCH_QUERIES_FILE, "w", encoding="utf-8") as f:
         yaml.dump(queries, f, allow_unicode=True) # use utf-8
 
+def format_keywords(keywords):
+    return ", ".join(keywords) if keywords else "none"
+
+def format_authors(authors):
+    return ", ".join(authors) if authors else "none"
+
 def main():
-    
     parser = argparse.ArgumentParser(prog="paper-trackr", description="track recent papers from PubMed, EuropePMC and bioRxiv")
+    parser.add_argument("configure", nargs="?", help="interactively set up your email accounts")
     parser.add_argument("--dry-run", action="store_true", help="run without sending email")
     parser.add_argument("--limit", type=int, default=10, help="limit the number of requested papers")
     parser.add_argument("--keywords", nargs="+", help="personalized keywords")
@@ -30,12 +39,23 @@ def main():
     parser.add_argument("--sources", nargs="+", choices=["bioRxiv", "PubMed", "EuropePMC"])
     args = parser.parse_args()
     
-    # load accounts
-    with open("paper-trackr/config/accounts.yml") as f:
-        accounts = yaml.safe_load(f)
+    if args.configure == "configure":
+        configure_email_accounts()
+        sys.exit(0)
+    
+    # check email configuration only if NOT in dry-run
+    if not args.dry_run:
+        if not os.path.exists(CONFIG_PATH):
+            print("Email configuration file not found: paper-trackr/config/accounts.yml")
+            print("Run `paper-trackr configure` to set up your email account.")
+            sys.exit(1)
 
-    sender_email = accounts["sender"]["email"]
-    password = accounts["sender"]["password"]
+        # load accounts
+        with open(CONFIG_PATH) as f:
+            accounts = yaml.safe_load(f)
+
+        sender_email = accounts["sender"]["email"]
+        password = accounts["sender"]["password"]
  
     init_db()
     new_articles = []
@@ -54,29 +74,51 @@ def main():
     else:
         search_queries = load_search_queries()
 
-    for query in search_queries:
+    print("Starting paper-trackr search...")
+
+    for i, query in enumerate(search_queries, start=1):
         keywords = query["keywords"]
         authors = query["authors"]
         sources = query["sources"]
 
+        print(f"\nQuery {i}:")
+        print(f"    keywords: {format_keywords(keywords)}")
+        print(f"    authors: {format_authors(authors)}")
+        print(f"    sources: {', '.join(sources)}\n")
+
         if "bioRxiv" in sources:
+            print(f"    Searching bioRxiv...")
             new_articles.extend(check_biorxiv_feeds(keywords, authors)[:args.limit])
 
         if "PubMed" in sources:
+            print(f"    Searching PubMed...")
             new_articles.extend(search_pubmed(keywords, authors)[:args.limit])
 
         if "EuropePMC" in sources:
+            print(f"    Searching EuropePMC...")
             new_articles.extend(search_epmc(keywords, authors)[:args.limit])
 
+    print("\nSearch finished.\n")
+    
     # save and send new papers 
     filtered_articles = []
     for art in new_articles:
         if is_article_new(art["link"], art["title"]):
             save_article(art["title"], art["abstract"], art.get("source", "unknown"), art["link"])
-            print(f'[Saved] {art["title"]} ({art.get("source", "unknown")})')
+            print(f'    [Saved] {art["title"]} ({art.get("source", "unknown")})')
             filtered_articles.append(art)
 
     if not args.dry_run and filtered_articles:
+        print(f"\nSending {len(filtered_articles)} new paper(s) via email...")
         for receiver in accounts["receiver"]:
             receiver_email = receiver["email"]
             send_email(filtered_articles, sender_email, receiver_email, password)
+        print("Emails sent successfully!\n")
+   
+    elif not args.dry_run and not filtered_articles:
+        print("No new paper(s) found - no emails were sent.\n")
+    elif args.dry_run:
+        if filtered_articles:
+            print(f"\ndry-run: {len(filtered_articles)} new paper(s) would have been sent.\n")
+        else:
+            print(f"dry-run: no new paper(s) found - nothing would have been sent.\n")

--- a/paper-trackr/core/configure.py
+++ b/paper-trackr/core/configure.py
@@ -1,0 +1,38 @@
+import questionary
+import yaml
+import os
+
+CONFIG_PATH = "paper-trackr/config/accounts.yml"
+
+def configure_email_accounts():
+    print("Welcome to paper-trackr email configuration")
+
+    # verify if accounts.yaml exists
+    if os.path.exists(CONFIG_PATH):
+        overwrite = questionary.confirm("An existing config was found. Overwrite?").ask()
+        if not overwrite:
+            print("Configuration canceled.")
+            return
+
+    # configure user emails 
+    sender_email = questionary.text("Enter sender email:").ask()
+    sender_password = questionary.password("Enter sender password (Google App Password):").ask()
+    receivers = questionary.text("Enter receiver emails (comma-separated):").ask()
+
+    # create yaml structure
+    receiver_list = [{'email': r.strip()} for r in receivers.split(",")]
+
+    config = {
+        'sender': {
+            'email': sender_email,
+            'password': sender_password
+        },
+        'receiver': receiver_list
+    }
+
+    # save configuration 
+    os.makedirs(os.path.dirname(CONFIG_PATH), exist_ok=True)
+    with open(CONFIG_PATH, "w") as f:
+        yaml.dump(config, f)
+
+    print("Configuration saved to paper-trackr/config/accounts.yml")

--- a/paper-trackr/templates/newsletter_template.html
+++ b/paper-trackr/templates/newsletter_template.html
@@ -12,7 +12,7 @@
         <hr style="margin: 20px 0;">
         {{ articles_html }}
         <p style="font-size: 14px; color: gray;">
-            You’re receiving this email because you subscribed to
+            You’re receiving this email because you're using
             <a href="https://github.com/felipevzps/paper-trackr" style="color: #1a0dab; text-decoration: none;">paper-trackr</a>.
             Stay curious!
         </p>


### PR DESCRIPTION
just a couple of small but useful improvements:

added clear log messages to show progress during paper search and email sending steps (this helps track what's going on during execution)  
also added a quick setup for `accounts.yml`, so users don’t have to edit the config file manually anymore  
it’s all handled interactively via `paper-trackr configure` (using pretty CLI prompt by [questionary](https://github.com/tmbo/questionary))

this should make the tool easier to configure, especially for first-timers