### PR TITLE
add "manage" to configure queries

### DIFF
--- a/paper-trackr/core/epmc_request.py
+++ b/paper-trackr/core/epmc_request.py
@@ -3,11 +3,11 @@ from datetime import datetime, timedelta
 
 # API source: https://europepmc.org/RestfulWebService
 
-def search_epmc(keywords, authors):
-    # get date from the last 30 days
+def search_epmc(keywords, authors, days):
+    # get date from the last N days
     today = datetime.today()
-    thirty_days_ago = today - timedelta(days=30)
-    start_str = thirty_days_ago.strftime("%Y-%m-%d")
+    days_ago = today - timedelta(days)
+    start_str = days_ago.strftime("%Y-%m-%d")
     end_str = today.strftime("%Y-%m-%d")
 
     query_parts = []
@@ -18,7 +18,7 @@ def search_epmc(keywords, authors):
     for author in authors:
         query_parts.append(f'AUTH:"{author}"')
     
-    # filter publications by the last 30 days
+    # filter publications by the last N days
     query_parts.append(f"FIRST_PDATE:[{start_str} TO {end_str}]")
 
     query = " AND ".join(query_parts)

--- a/paper-trackr/core/pubmed_request.py
+++ b/paper-trackr/core/pubmed_request.py
@@ -2,12 +2,12 @@ import requests
 from datetime import datetime, timedelta
 import xml.etree.ElementTree as ET
 
-def search_pubmed(keywords, authors):
+def search_pubmed(keywords, authors, days):
     today = datetime.today()
-    thirty_days_ago = today - timedelta(days=30)
+    days_ago = today - timedelta(days)
     
     # format date in the pubmed format 
-    start_date = thirty_days_ago.strftime("%Y/%m/%d")
+    start_date = days_ago.strftime("%Y/%m/%d")
     end_date = today.strftime("%Y/%m/%d")
     
     # create query with keyword and author fields


### PR DESCRIPTION
added a new subcommand (`paper-tracker manage`) to simplify the handling of `search_queries.yml`, allowing users to `add`, `list`, `delete`, or `clear` their saved queries without needing to manually edit the YAML config file.  

this improves usability and aligns with the interactive design already introduced in the `paper-trackr configure` added here -> #5 

## usage examples

```bash
# interactively add a new search query
python paper-trackr/main.py manage --add

No saved search queries found.
Creating empty query file at: paper-trackr/config/search_queries.yml
Would you like to create your first search query now? (y/N): y
Enter keywords (separated by space, or leave empty): bioinformatis genomics
Enter authors (separated by space, or leave empty):
Enter sources (bioRxiv, PubMed, EuropePMC — separated by space, or leave empty for all): bioRxiv
Search query saved.
```  
```bash
# list all saved queries
python paper-trackr/main.py manage --list

Saved queries:
  [1] keywords: bioinformatics, genomics | authors: none | sources: bioRxiv
```  
```bash
# delete the 1st query
python paper-trackr/main.py manage --delete 1

Query #1 removed.
```  
```bash
# clear all saved queries (asks for confirmation)
python paper-trackr/main.py manage --clear

Are you sure you want to delete all saved queries? (y/N): y
All queries deleted.
```  