### PR TITLE
add a param to save html

### DIFF
--- a/paper_trackr/core/actions.py
+++ b/paper_trackr/core/actions.py
@@ -63,6 +63,7 @@ def main():
     parser.add_argument("--dry-run", action="store_true", help="run without sending email")
     parser.add_argument("--limit", type=int, default=10, help="limit the number of requested papers")
     parser.add_argument("--days", type=int, default=3, help="search publications in the last N days")
+    parser.add_argument("--save_html", action="store_true", help="save html page before sending email")
     args = parser.parse_args()
 
     # configure
@@ -179,7 +180,7 @@ def main():
         print(f"\nSending {len(filtered_articles)} new paper(s) via email...")
         for receiver in accounts["receiver"]:
             receiver_email = receiver["email"]
-            send_email(filtered_articles, sender_email, receiver_email, password)
+            send_email(filtered_articles, sender_email, receiver_email, password, save_html=args.save_html)
         print("Emails sent successfully!\n")
     elif not args.dry_run and not filtered_articles:
         print("No new paper(s) found - no emails were sent.\n")

--- a/paper_trackr/core/mailer.py
+++ b/paper_trackr/core/mailer.py
@@ -7,6 +7,7 @@ from email.mime.multipart import MIMEMultipart
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 HTML_TEMPLATE = os.path.join(BASE_DIR, "../templates/newsletter_template.html")
+NEWSLETTER_DIR = os.path.join(BASE_DIR, "../newsletter/paper-trackr_newsletter.html")
 
 def load_template(path):
     with open(path, "r", encoding="utf-8") as f:
@@ -48,7 +49,7 @@ def compose_email_body(template_path, articles):
     articles_html = generate_article_html(articles)
     return template.replace("{{ date }}", today).replace("{{ articles_html }}", articles_html)
 
-def send_email(articles, sender_email, receiver_email, password):
+def send_email(articles, sender_email, receiver_email, password, save_html=False):
     if not articles:
         return
 
@@ -60,6 +61,11 @@ def send_email(articles, sender_email, receiver_email, password):
 
     html_body = compose_email_body(HTML_TEMPLATE, articles)
     msg.attach(MIMEText(html_body, "html"))
+    
+    if save_html:
+        print(f"Saving html to {NEWSLETTER_DIR}")
+        with open(NEWSLETTER_DIR, "w", encoding="utf-8") as f:
+            f.write(html_body)
 
     with smtplib.SMTP_SSL("smtp.gmail.com", 465) as server:
         server.login(sender_email, password)


### PR DESCRIPTION
add an optional parameter: `--save-html` 
now its possible to save the html page before sending email:

````bash
paper-trackr --save-html
````