### PR TITLE
update decoder params

### DIFF
--- a/paper_trackr/config/global_settings.py
+++ b/paper_trackr/config/global_settings.py
@@ -30,6 +30,8 @@ SCITLDR_SOURCE_FILE = "paper-trackr_abstracts.source"
 SCITLDR_TEST_FILE = "paper-trackr.tldr"
 SCITLDR_BART_XSUM = "scitldr_bart-xsum.tldr-ao.pt"
 
-# scitldr optimal decoder params
-BART_XSUM_BEAM = "2"
-BART_XSUM_LENPAN = "0.8"
+# scitldr optimal decoder params for paper-trackr
+BEAM_SIZE = "2"
+LENGTH_PENALTY = "1"
+MAX_LENGTH = "60"
+MIN_LENGTH = "10"

--- a/paper_trackr/core/generate_tldr.py
+++ b/paper_trackr/core/generate_tldr.py
@@ -1,6 +1,6 @@
 import subprocess
-from paper_trackr.config.global_settings import SCITLDR_DIR, SCITLDR_DATA_DIR, SCITLDR_MODEL_DIR, SCITLDR_OUT_DIR, SCITLDR_DATA_SUBDIR, SCITLDR_SOURCE_FILE, SCITLDR_TEST_FILE, SCITLDR_BART_XSUM, BART_XSUM_BEAM, BART_XSUM_LENPAN
 from pathlib import Path
+from paper_trackr.config.global_settings import SCITLDR_DIR, SCITLDR_DATA_DIR, SCITLDR_MODEL_DIR, SCITLDR_OUT_DIR, SCITLDR_DATA_SUBDIR, SCITLDR_SOURCE_FILE, SCITLDR_TEST_FILE, SCITLDR_BART_XSUM, BEAM_SIZE, LENGTH_PENALTY, MAX_LENGTH, MIN_LENGTH
 
 def prepare_abstract_source_file(articles):
     source_path = SCITLDR_DATA_SUBDIR / SCITLDR_SOURCE_FILE
@@ -71,8 +71,10 @@ def run_scitldr_inference(articles):
             "--source_fname", SCITLDR_SOURCE_FILE,
             "--datadir", str(SCITLDR_DATA_DIR / SCITLDR_DATA_SUBDIR),
             "--outdir", str(SCITLDR_OUT_DIR),
-            "--beam", BART_XSUM_BEAM,
-            "--lenpen", BART_XSUM_LENPAN,
+            "--beam", BEAM_SIZE,
+            "--lenpen", LENGTH_PENALTY,
+            "--max_len_b", MAX_LENGTH,
+            "--min_len", MIN_LENGTH,
             "--test_fname", SCITLDR_TEST_FILE
         ], cwd=SCITLDR_DIR, check=True)
     


### PR DESCRIPTION
this PR updates the decoding parameters used for TLDR generation, fixing #13.  

after manually running several test cases on real abstracts, the following combination of parameters consistently produced more coherent and complete TLDRs:

```bash
beam: 2
lenpen: 1 # neutral setting (no length penalty applied)
max_len_b: 60
min_len: 10
```

this new configuration achieves a better balance between generation diversity and output length, producing summaries that are generally more informative and less likely to be fragmented/excessively short.

I did not perform an exhaustive parameter search and there is still room for further fine-tuning.  
however, this configuration already reduces TLDRs fragmentation, and I'm satisfied with the current results.

closes #13 