### PR TITLE
include author names

### DIFF
--- a/paper_trackr/core/actions.py
+++ b/paper_trackr/core/actions.py
@@ -69,7 +69,7 @@ def process_articles(new_articles):
     filtered_articles = []
     for art in new_articles:
         if is_article_new(art["link"], art["title"]):
-            save_article(title=art["title"], abstract=art["abstract"], tldr=art.get("tldr"), source=art.get("source", "unknown"), link=art["link"])
+            save_article(title=art["title"], author="".join(art["author"]), source=art.get("source", "unknown"), tldr=art.get("tldr"), abstract=art["abstract"], link=art["link"])
             print(f'    [Saved] {art["title"]} ({art.get("source", "unknown")})')
             filtered_articles.append(art)
     return filtered_articles

--- a/paper_trackr/core/biorxiv_request.py
+++ b/paper_trackr/core/biorxiv_request.py
@@ -17,18 +17,19 @@ def parse_biorxiv_results(feed, authors):
 
     for entry in feed.entries:
         title = entry.get("title", "")
-        link = entry.get("link", "")
+        author = entry.get("author", "")
         abstract = entry.get("description", "")
-        author_line = entry.get("author", "")
+        link = entry.get("link", "")
 
-        author_match = not authors or any(a.lower() in author_line.lower() for a in authors)
+        author_match = not authors or any(a.lower() in author.lower() for a in authors)
 
         if author_match:
             articles.append({
                 "title": title,
-                "link": link,
-                "abstract": abstract,
+                "author":  author,
                 "source": "bioRxiv",
+                "abstract": abstract,
+                "link": link,
             })
 
     return articles

--- a/paper_trackr/core/db_utils.py
+++ b/paper_trackr/core/db_utils.py
@@ -11,9 +11,10 @@ def init_db():
                     id INTEGER PRIMARY KEY,
                     date_added TIMESTAMP,
                     title TEXT,
-                    abstract TEXT,
-                    tldr TEXT,
+                    author TEXT,
                     source TEXT,
+                    tldr TEXT,
+                    abstract TEXT,
                     link TEXT UNIQUE
                 )''')
     conn.commit()
@@ -28,35 +29,37 @@ def is_article_new(link, title):
     conn.close()
     return result is None
 
-def save_article(title, abstract, source, link, tldr=None):
+def save_article(title, author, source, abstract, link, tldr=None):
     if is_article_new(link, title):
         conn = sqlite3.connect(DB_FILE)
         c = conn.cursor()
-        c.execute("INSERT INTO articles (date_added, title, abstract, tldr, source, link) VALUES (?, ?, ?, ?, ?, ?)",
-                  (datetime.now(), title, abstract, tldr, source, link))
+        c.execute("INSERT INTO articles (date_added, title, author, source, tldr, abstract, link) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                  (datetime.now(), title, author, source, tldr, abstract, link))
         conn.commit()
         conn.close()
 
         log_history({
             "title": title,
-            "abstract": abstract,
-            "tldr": tldr,
+            "author": author, 
             "source": source,
+            "tldr": tldr,
+            "abstract": abstract,
             "link": link
         })
 
 def log_history(article):
     with open(HISTORY_FILE, mode="a", newline="") as csvfile:
-        fieldnames = ["date", "title", "abstract", "tldr", "source", "link"]
+        fieldnames = ["date", "title", "author", "source", "tldr", "abstract", "link"]
         writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
         if not Path(HISTORY_FILE).exists():
             writer.writeheader()
         writer.writerow({
             "date": datetime.now().strftime("%Y-%m-%d %H:%M"),
             "title": article["title"],
-            "abstract": article["abstract"],
-            "tldr": article.get("tldr", ""),
+            "author": article["author"],
             "source": article.get("source", "unknown"),
+            "tldr": article.get("tldr", ""),
+            "abstract": article["abstract"],
             "link": article["link"],
         })
 

--- a/paper_trackr/core/epmc_request.py
+++ b/paper_trackr/core/epmc_request.py
@@ -42,8 +42,9 @@ def parse_epmc_results(results):
     for result in results:
         article_id = result.get("id", "")
         title = result.get("title", "")
-        abstract = result.get("abstractText", "")
+        author = result.get("authorString", "")
         source = result.get("source", "")
+        abstract = result.get("abstractText", "")
         doi = result.get("doi", "")
 
         if source == "MED":
@@ -57,9 +58,10 @@ def parse_epmc_results(results):
 
         articles.append({
             "title": title,
-            "link": link,
-            "abstract": abstract,
+            "author": author,
             "source": source,
+            "abstract": abstract,
+            "link": link,
         })
 
     return articles

--- a/paper_trackr/core/mailer.py
+++ b/paper_trackr/core/mailer.py
@@ -44,6 +44,7 @@ def generate_article_html(articles):
         article_html = f"""
             <div style="margin-bottom: 30px;">
                 <h2 style="color: #000000; font-size: 22px;">{a["title"]}</h2>
+                <p style="font-size: 14px; text-align: justify; margin-top: -10px; margin-bottom: 10px;"> {a["author"]}</p>
                 <p style="font-size: 16px;"><em>Source: {a["source"]}</em></p>
                 {formatted_abstract}
                 <p><a href="{a["link"]}" style="color: #1a0dab; font-size: 16px;">Read full paper</a></p>

--- a/paper_trackr/core/pubmed_request.py
+++ b/paper_trackr/core/pubmed_request.py
@@ -56,12 +56,21 @@ def parse_pubmed_results(root):
         title = article.findtext(".//ArticleTitle", default="")
         abstract = article.findtext(".//Abstract/AbstractText", default="")
         pmid = article.findtext(".//PMID", default="")
-
+        
+        authors = [] 
+        for author in article.findall(".//AuthorList/Author"):
+            first = author.findtext("ForeName", default="")
+            last = author.findtext("LastName", default="")
+            full_name = f"{first} {last}".strip()
+            if full_name:
+                authors.append(full_name)
+        
         articles.append({
             "title": title,
+            "author": ", ".join(authors),
+            "source": "PubMed",
             "abstract": abstract,
             "link": f"https://pubmed.ncbi.nlm.nih.gov/{pmid}/",
-            "source": "PubMed"
         })
     return articles
 


### PR DESCRIPTION
i was forgetting one of the most important parts of any paper… the authors!  
it’s really cool to follow new publications and recognize the people behind the research.  

this PR update the APIs integration (bioRxiv, PubMed, EuropePMC) to fetch author names and includes them right below the paper title in the newsletter.  

now each paper in paper-trackr gives proper credit to the researchers pushing the field forward.