### PR TITLE
get publication date

### DIFF
--- a/paper_trackr/core/actions.py
+++ b/paper_trackr/core/actions.py
@@ -70,7 +70,7 @@ def process_articles(new_articles):
     for art in new_articles:
         # check if has abstract and is new  
         if art.get("abstract") and is_article_new(art["link"], art["title"]):
-            save_article(title=art["title"], author="".join(art["author"]), source=art.get("source", "unknown"), tldr=art.get("tldr"), abstract=art["abstract"], link=art["link"])
+            save_article(title=art["title"], author="".join(art["author"]), source=art.get("source", "unknown"), publication_date=art.get("date"), tldr=art.get("tldr"), abstract=art["abstract"], link=art["link"])
             print(f'    [Saved] {art["title"]} ({art.get("source", "unknown")})')
             filtered_articles.append(art)
     return filtered_articles

--- a/paper_trackr/core/biorxiv_request.py
+++ b/paper_trackr/core/biorxiv_request.py
@@ -18,6 +18,7 @@ def parse_biorxiv_results(feed, authors):
     for entry in feed.entries:
         title = entry.get("title", "")
         author = entry.get("author", "")
+        date = entry.get("date", "")
         abstract = entry.get("description", "")
         link = entry.get("link", "")
 
@@ -28,6 +29,7 @@ def parse_biorxiv_results(feed, authors):
                 "title": title,
                 "author":  author,
                 "source": "bioRxiv",
+                "date": date,
                 "abstract": abstract,
                 "link": link,
             })

--- a/paper_trackr/core/db_utils.py
+++ b/paper_trackr/core/db_utils.py
@@ -13,6 +13,7 @@ def init_db():
                     title TEXT,
                     author TEXT,
                     source TEXT,
+                    publication_date DATE,
                     tldr TEXT,
                     abstract TEXT,
                     link TEXT UNIQUE
@@ -29,12 +30,12 @@ def is_article_new(link, title):
     conn.close()
     return result is None
 
-def save_article(title, author, source, abstract, link, tldr=None):
+def save_article(title, author, source, abstract, link, publication_date=None, tldr=None):
     if is_article_new(link, title):
         conn = sqlite3.connect(DB_FILE)
         c = conn.cursor()
-        c.execute("INSERT INTO articles (date_added, title, author, source, tldr, abstract, link) VALUES (?, ?, ?, ?, ?, ?, ?)",
-                  (datetime.now(), title, author, source, tldr, abstract, link))
+        c.execute("INSERT INTO articles (date_added, title, author, source, publication_date, tldr, abstract, link) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                  (datetime.now(), title, author, source, publication_date, tldr, abstract, link))
         conn.commit()
         conn.close()
 
@@ -42,6 +43,7 @@ def save_article(title, author, source, abstract, link, tldr=None):
             "title": title,
             "author": author, 
             "source": source,
+            "publication_date": publication_date,
             "tldr": tldr,
             "abstract": abstract,
             "link": link
@@ -49,7 +51,7 @@ def save_article(title, author, source, abstract, link, tldr=None):
 
 def log_history(article):
     with open(HISTORY_FILE, mode="a", newline="") as csvfile:
-        fieldnames = ["date", "title", "author", "source", "tldr", "abstract", "link"]
+        fieldnames = ["date", "title", "author", "source", "publication_date", "tldr", "abstract", "link"]
         writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
         if not Path(HISTORY_FILE).exists():
             writer.writeheader()
@@ -58,6 +60,7 @@ def log_history(article):
             "title": article["title"],
             "author": article["author"],
             "source": article.get("source", "unknown"),
+            "publication_date": article.get("publication_date", ""),
             "tldr": article.get("tldr", ""),
             "abstract": article["abstract"],
             "link": article["link"],

--- a/paper_trackr/core/epmc_request.py
+++ b/paper_trackr/core/epmc_request.py
@@ -44,6 +44,7 @@ def parse_epmc_results(results):
         title = result.get("title", "")
         author = result.get("authorString", "")
         source = result.get("source", "")
+        date = result.get("firstPublicationDate", "")
         abstract = result.get("abstractText", "")
         doi = result.get("doi", "")
 
@@ -60,6 +61,7 @@ def parse_epmc_results(results):
             "title": title,
             "author": author,
             "source": source,
+            "date": date,
             "abstract": abstract,
             "link": link,
         })

--- a/paper_trackr/core/mailer.py
+++ b/paper_trackr/core/mailer.py
@@ -45,7 +45,12 @@ def generate_article_html(articles):
             <div style="margin-bottom: 30px;">
                 <h2 style="color: #000000; font-size: 22px;">{a["title"]}</h2>
                 <p style="font-size: 14px; text-align: justify; margin-top: -10px; margin-bottom: 10px;"> {a["author"]}</p>
-                <p style="font-size: 16px;"><em>Source: {a["source"]}</em></p>
+                
+                <p style="font-size: 16px; display: flex; justify-content: space-between;">
+                    <em>Source: {a["source"]}</em>
+                    <em><span>Published: {a["date"]}</span></em>
+                </p>
+
                 {formatted_abstract}
                 <p><a href="{a["link"]}" style="color: #1a0dab; font-size: 16px;">Read full paper</a></p>
             </div>

--- a/paper_trackr/core/pubmed_request.py
+++ b/paper_trackr/core/pubmed_request.py
@@ -56,6 +56,13 @@ def parse_pubmed_results(root):
         title = article.findtext(".//ArticleTitle", default="")
         abstract = article.findtext(".//Abstract/AbstractText", default="")
         pmid = article.findtext(".//PMID", default="")
+
+        # get published date (YYYY-MM-DD)
+        pub_date_elem = article.find(".//Article/ArticleDate")
+        year = pub_date_elem.findtext("Year", default="")
+        month = pub_date_elem.findtext("Month", default="")
+        day = pub_date_elem.findtext("Day", default="")
+        date = "-".join(filter(None, [year, month, day]))
         
         authors = [] 
         for author in article.findall(".//AuthorList/Author"):
@@ -69,6 +76,7 @@ def parse_pubmed_results(root):
             "title": title,
             "author": ", ".join(authors),
             "source": "PubMed",
+            "date": date, 
             "abstract": abstract,
             "link": f"https://pubmed.ncbi.nlm.nih.gov/{pmid}/",
         })


### PR DESCRIPTION
this PR introduces the following updates:

* capture of `publication_date` for papers retrieved from bioRxiv, PubMed, and EuropePMC  
* add the `publication_date` (DATE field) to the SQLite3 database (`articles.db`)
* updated newsletter html layout to display the publication date (`Published YYYY-MM-DD)

now the newsletter clearly shows when each paper was published, improving transparency and allowing readers to quickly see if the paper is rlly new.

its also lays the groundwork for potential future features, such as: `filtering by publication date` or `prioritizing the most recent papers` - that last one should be simple and useful.