### PR TITLE
Save keywords

### DIFF
--- a/paper_trackr/core/actions.py
+++ b/paper_trackr/core/actions.py
@@ -70,7 +70,7 @@ def process_articles(new_articles):
     for art in new_articles:
         # check if paper has abstract and if paper is new 
         if art.get("abstract") and is_article_new(art["link"], art["title"]):
-            article_id = save_article(title=art["title"], author="".join(art["author"]), source=art.get("source", "unknown"), publication_date=art.get("date"), tldr=art.get("tldr"), abstract=art["abstract"], link=art["link"])
+            article_id = save_article(title=art["title"], author="".join(art["author"]), source=art.get("source", "unknown"), publication_date=art.get("date"), tldr=art.get("tldr"), abstract=art["abstract"], link=art["link"], keyword=art["keyword"])
             saved_articles_ids.append(article_id)
     return saved_articles_ids
 

--- a/paper_trackr/core/biorxiv_request.py
+++ b/paper_trackr/core/biorxiv_request.py
@@ -12,7 +12,7 @@ def fetch_biorxiv_results(url):
     return feedparser.parse(url)
 
 # parse bioRxiv results
-def parse_biorxiv_results(feed, authors):
+def parse_biorxiv_results(feed, authors, keywords):
     articles = []
 
     for entry in feed.entries:
@@ -32,6 +32,7 @@ def parse_biorxiv_results(feed, authors):
                 "date": date,
                 "abstract": abstract,
                 "link": link,
+                "keyword": keywords,
             })
 
     return articles
@@ -40,4 +41,4 @@ def parse_biorxiv_results(feed, authors):
 def search_biorxiv(keywords, authors):
     url = build_biorxiv_query(keywords)
     feed = fetch_biorxiv_results(url)
-    return parse_biorxiv_results(feed, authors)
+    return parse_biorxiv_results(feed, authors, keywords)

--- a/paper_trackr/core/epmc_request.py
+++ b/paper_trackr/core/epmc_request.py
@@ -36,7 +36,7 @@ def fetch_epmc_results(query):
     return response.json().get("resultList", {}).get("result", [])
 
 # parse Europe PMC API results
-def parse_epmc_results(results):
+def parse_epmc_results(results, keywords):
     articles = []
 
     for result in results:
@@ -64,6 +64,7 @@ def parse_epmc_results(results):
             "date": date,
             "abstract": abstract,
             "link": link,
+            "keyword": keywords,
         })
 
     return articles
@@ -72,4 +73,4 @@ def parse_epmc_results(results):
 def search_epmc(keywords, authors, days):
     query = build_epmc_query(keywords, authors, days)
     results = fetch_epmc_results(query)
-    return parse_epmc_results(results)
+    return parse_epmc_results(results, keywords)

--- a/paper_trackr/core/generate_color.py
+++ b/paper_trackr/core/generate_color.py
@@ -1,0 +1,44 @@
+import hashlib
+
+# generate a hash for keyword and transform to hexcolor (only 6 first chars of the hex)
+# ngl, im pretty happy with that way to generate persistent colors!
+def keyword_to_color(keyword):
+    hash_object = hashlib.md5(keyword.encode())     # generate an md5 hash 
+    hex_digest = hash_object.hexdigest()            # convert hash to hex 
+    color = f"#{hex_digest[:6]}"                    # keep the first 6 chars of the hex
+    return color 
+
+
+# generate pastel colors to background
+def keyword_to_pastel_color(keyword):
+    hash_object = hashlib.md5(keyword.encode())
+    hash_digest = hash_object.hexdigest()
+    
+    # use part of the hash to create RGB values
+    r = int(hash_digest[0:2], 16)
+    g = int(hash_digest[2:4], 16)
+    b = int(hash_digest[4:6], 16)
+
+    # adjust the color to make it lighter, giving it a pastel appearance
+    r = int((r + 255) / 2)
+    g = int((g + 255) / 2)
+    b = int((b + 255) / 2)
+
+    # return the color in hexadecimal format 
+    return f'#{r:02x}{g:02x}{b:02x}'
+
+
+# generate text colors (if the background is light, return black text, otherwise white)
+def get_contrast_text_color(bg_hex_color):
+    # convert hex color to RGB values 
+    bg_hex_color = bg_hex_color.lstrip('#')
+    r = int(bg_hex_color[0:2], 16)
+    g = int(bg_hex_color[2:4], 16)
+    b = int(bg_hex_color[4:6], 16)
+
+    # calculate perceptual luminance of the background color 
+    luminance = (0.299 * r + 0.587 * g + 0.114 * b)
+
+    # return black text if background is light 
+    # return white text if background is dark
+    return '#000000' if luminance > 186 else '#ffffff'

--- a/paper_trackr/core/mailer.py
+++ b/paper_trackr/core/mailer.py
@@ -4,11 +4,13 @@ from datetime import datetime
 from email.mime.text import MIMEText
 from email.mime.multipart import MIMEMultipart
 from paper_trackr.config.global_settings import TEMPLATE_FILE, NEWSLETTER_OUTPUT
+from paper_trackr.core.generate_color import keyword_to_color, keyword_to_pastel_color, get_contrast_text_color
 
 # read html template
 def load_template(path):
     with open(path, "r", encoding="utf-8") as f:
         return f.read()
+
 
 # generate the html body for each new paper found in a specific date
 def generate_article_html(articles):
@@ -41,11 +43,20 @@ def generate_article_html(articles):
         # merge tldr + abstract 
         formatted_abstract = tldr_html + abstract_html 
 
+        
+        #color = keyword_to_color(a["keyword"])
+        color = keyword_to_pastel_color(a["keyword"])
+        keyword_html = f'<span style="background-color: {color}; color: #000000; padding: 4px 8px; border-radius: 12px; font-size: 14px; box-shadow: 1px 1px 3px rgba(0, 0, 0, 0.5);">{a["keyword"]}</span>'
+         
+        #bg_color = keyword_to_pastel_color(a["keyword"])
+        #text_color = get_contrast_text_color(bg_color)
+        #keyword_html = f'<span style="background-color: {bg_color}; color: {text_color}; padding: 3px 8px; margin: 2px; font-size: 0.85em;">{a["keyword"]}</span>'
+
         article_html = f"""
             <div style="margin-bottom: 30px;">
                 <h2 style="color: #000000; font-size: 22px;">{a["title"]}</h2>
                 <p style="font-size: 14px; text-align: justify; margin-top: -10px; margin-bottom: 10px;"> {a["author"]}</p>
-                
+         
                 <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="font-size:16px; margin-bottom: 12px;">
                     <tr>
                         <td align="left" style="font-style: italic;">
@@ -56,7 +67,8 @@ def generate_article_html(articles):
                         </td>
                     </tr>
                 </table>
-
+            
+                <p>{keyword_html}</p>
                 {formatted_abstract}
                 <p><a href="{a["link"]}" style="color: #1a0dab; font-size: 16px;">Read full paper</a></p>
             </div>
@@ -66,12 +78,14 @@ def generate_article_html(articles):
 
     return "\n".join(html_parts)
 
+
 # create updated html body
 def compose_email_body(template_path, articles):
     today = datetime.now().strftime("%A, %d %B %Y")
     template = load_template(template_path)
     articles_html = generate_article_html(articles)
     return template.replace("{{ date }}", today).replace("{{ articles_html }}", articles_html)
+
 
 # send newsletter email with new papers
 def send_email(articles, sender_email, receiver_email, password):
@@ -90,6 +104,7 @@ def send_email(articles, sender_email, receiver_email, password):
     with smtplib.SMTP_SSL("smtp.gmail.com", 465) as server:
         server.login(sender_email, password)
         server.sendmail(sender_email, receiver_email, msg.as_string())
+
 
 # save newsletter html using template
 def save_newsletter_html(articles):

--- a/paper_trackr/core/pubmed_request.py
+++ b/paper_trackr/core/pubmed_request.py
@@ -50,7 +50,7 @@ def fetch_pubmed_metadata(results):
     return ET.fromstring(response.content)
 
 # parse entrez API results and extract paper abstract and link
-def parse_pubmed_results(root):
+def parse_pubmed_results(root, keywords):
     articles = []
     for article in root.findall(".//PubmedArticle"):
         title = article.findtext(".//ArticleTitle", default="")
@@ -79,6 +79,7 @@ def parse_pubmed_results(root):
             "date": date, 
             "abstract": abstract,
             "link": f"https://pubmed.ncbi.nlm.nih.gov/{pmid}/",
+            "keyword": keywords,
         })
     return articles
 
@@ -91,4 +92,4 @@ def search_pubmed(keywords, authors, days):
         return []
 
     xml_root = fetch_pubmed_metadata(results)
-    return parse_pubmed_results(xml_root)
+    return parse_pubmed_results(xml_root, keywords)


### PR DESCRIPTION
this PR introduces a couple of important improvements:

1. **keywords saved in the database**: now, the keywords used to retrieve paper are saved in the sqlite3 database. Ensuring that the keyword-paper association is persistent, enabling easier reference.

2. **keywords displayed in the newsletter**: keywords are now displayed in the newsletter for transparency. It can also serve as a hint for users to better understand which papers might appeal to them based on the keywords.

my favorite part of this update was working on the keyword colors in the HTML.  
i’m really happy with the solution implemented:

each keyword is transformed into an MD5 hash, then the hash is converted to hex. The first 6 characters of the hex value are used to assign colors to the keywords. e.g.:
```python
def keyword_to_color(keyword):
    hash_object = hashlib.md5(keyword.encode())     # generate an md5 hash 
    hex_digest = hash_object.hexdigest()            # convert hash to hex 
    color = f"#{hex_digest[:6]}"                    # keep the first 6 chars of the hex
    return color 
```

this solution solves the problem of assigning a specific color to each keyword, as the same keyword will always produce the same color due to the consistent hash.

pretty cool feature!